### PR TITLE
New URL added to run createTransaction

### DIFF
--- a/app/server.js
+++ b/app/server.js
@@ -2,7 +2,7 @@ const Hapi = require('hapi')
 const Joi = require('joi')
 const S = Joi.string
 const scheduledJobs = require('../lib/scheduledJobs')
-
+const createTestRun = require('../app/js/app').createTestRun
 const server = new Hapi.Server()
 
 server.connection({ port: process.env.PORT || 3000 })
@@ -29,6 +29,16 @@ server.route([
       },
       validate: {
         query: { address: S().required(), key: S().required() }
+      }
+    }
+  },
+  {
+    method: 'GET',
+    path: '/createTransaction',
+    config: {
+      handler: function (request, reply) {
+        createTestRun()
+        reply(`Transaction created`)
       }
     }
   }


### PR DESCRIPTION
Hi @smuemd 

Create new GET request to create transaction, this URL can be called from any server (cron or other schedulers) to avoid running cron using Heroku

https://salepartner.herokuapp.com/createTransaction